### PR TITLE
Fix default config button colors

### DIFF
--- a/src/config_storage.cpp
+++ b/src/config_storage.cpp
@@ -46,7 +46,7 @@ void load_default_config()
       buttonLogic[i][j].holdRelease.type = ACTION_NONE;
       buttonLogic[i][j].release.type = ACTION_NONE;
 
-      buttonColors[0][j] = LED_COLOR_DEFAULT;
+      buttonColors[i][j] = LED_COLOR_DEFAULT;
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure each layer has default LED color
- add trailing newline at end of config storage file

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6849e24e0ab88324a96b6b6ef420be8c