### PR TITLE
Fix README link to Russian version

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,6 @@
 # 🚀 ESP32 AirMouse
 
-[🇷🇺 Русская версия](./README_RU.md)
+[🇷🇺 Русская версия](./README.MD)
 
 ESP32 AirMouse — a project implementing a wireless air mouse device.
 


### PR DESCRIPTION
## Summary
- update Russian documentation link in `README_EN.md`
- verify link resolves correctly in rendered output

## Testing
- `python3 - <<'EOF'
import markdown, os
from bs4 import BeautifulSoup
with open('README_EN.md', encoding='utf-8') as f:
    html = markdown.markdown(f.read())
    soup = BeautifulSoup(html, 'html.parser')
    link = soup.find('a', string=lambda x: x and 'Русская версия' in x)
    if link:
        print('Found link to', link.get('href'), 'exists:', os.path.exists(link.get('href').replace('./','')))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6849e3d43b6483249d9ebd8708085dae